### PR TITLE
update 'system' to 'developer' as per openai's update

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -9,7 +9,7 @@ import (
 
 // Chat message role defined by the OpenAI API.
 const (
-	ChatMessageRoleSystem    = "system"
+	ChatMessageRoleSystem    = "developer"
 	ChatMessageRoleUser      = "user"
 	ChatMessageRoleAssistant = "assistant"
 	ChatMessageRoleFunction  = "function"


### PR DESCRIPTION
OpenAI is replacing `system` messages with `developer` messages. See https://platform.openai.com/docs/guides/text-generation

> Messages with the developer role provide instructions to the model that are prioritized ahead of user messages, as described in the [chain of command section in the model spec](https://cdn.openai.com/spec/model-spec-2024-05-08.html#follow-the-chain-of-command). They typically describe how the model should generally behave and respond. This message role used to be called the system prompt, but it has been renamed to more accurately describe its place in the instruction-following hierarchy.